### PR TITLE
Do not issue `a` in slate, always `link` types. This is consistent with h…

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -34,4 +34,4 @@ jobs:
 
       # Unit tests
       - name: Unit tests
-        run: yarn test
+        run: yarn test:ci

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "start": "node ./src/server.js",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch --watchAll",
     "prettier": "./node_modules/.bin/prettier --single-quote --check '**/*.{js,json}'",
     "prettier:fix": "./node_modules/.bin/prettier --single-quote --write '**/*.{js,json}'",
     "lint": "./node_modules/eslint/bin/eslint.js --max-warnings=0 'src/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "start": "node ./src/server.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch --watchAll",
+    "test:ci": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand",
     "prettier": "./node_modules/.bin/prettier --single-quote --check '**/*.{js,json}'",
     "prettier:fix": "./node_modules/.bin/prettier --single-quote --write '**/*.{js,json}'",
     "lint": "./node_modules/eslint/bin/eslint.js --max-warnings=0 'src/**/*.js'",

--- a/src/converters/slate.js
+++ b/src/converters/slate.js
@@ -2,6 +2,27 @@ import { jsx } from 'slate-hyperscript';
 
 const getId = () => Math.floor(Math.random() * Math.pow(2, 24)).toString(32);
 
+const simpleLinkDeserializer = (el) => {
+  let parent = el;
+
+  let children = Array.from(parent.childNodes)
+    .map((el) => deserialize(el))
+    .flat();
+
+  if (!children.length) children = [''];
+
+  const attrs = {
+    type: 'link',
+    data: {
+      url: el.getAttribute('href'),
+      title: el.getAttribute('title'),
+      target: el.getAttribute('target'),
+    },
+  };
+
+  return jsx('element', attrs, children);
+};
+
 const deserialize = (el) => {
   if (el.nodeType === 3) {
     return el.textContent;
@@ -48,16 +69,7 @@ const deserialize = (el) => {
     case 'LI':
       return jsx('element', { type: 'li' }, children);
     case 'A':
-      return jsx(
-        'element',
-        {
-          type: 'a',
-          url: el.getAttribute('href'),
-          title: el.getAttribute('title'),
-          target: el.getAttribute('target'),
-        },
-        children,
-      );
+      return simpleLinkDeserializer(el);
     default:
       return jsx('element', { type: 'p' }, children);
   }

--- a/src/converters/slate.test.js
+++ b/src/converters/slate.test.js
@@ -238,10 +238,10 @@ describe('slateTextBlock processing a link', () => {
   test('will have a nested structure in the value', () => {
     const result = slateTextBlock(elem);
     const valueElement = result.value[0];
-    expect(valueElement['type']).toBe('a');
-    expect(valueElement['url']).toBe('https://plone.org/');
-    expect(valueElement['title']).toBe('Plone website');
-    expect(valueElement['target']).toBe('_blank');
+    expect(valueElement['type']).toBe('link');
+    expect(valueElement['data']['url']).toBe('https://plone.org/');
+    expect(valueElement['data']['title']).toBe('Plone website');
+    expect(valueElement['data']['target']).toBe('_blank');
     expect(valueElement['children'][0]['text']).toBe('Welcome to Plone!');
   });
 });
@@ -295,8 +295,8 @@ describe('slateTableBlock processing a table with a link', () => {
     expect(rows[0].cells[0].type).toBe('data');
     expect(rows[0].cells[0].value).toHaveLength(1);
     const value = rows[0].cells[0].value[0];
-    expect(value['type']).toBe('a');
-    expect(value['url']).toBe('https://plone.org');
+    expect(value['type']).toBe('link');
+    expect(value['data']['url']).toBe('https://plone.org');
     expect(value['children'][0]['text']).toBe('Plone');
   });
 });


### PR DESCRIPTION
…ow is the default behavior in slate.

This is the "light" approach instead of the full refactor in https://github.com/plone/blocks-conversion-tool/pull/4 for being more conservative.

The one in #4 should be finalised, tested and released as a breaking change.