### PR TITLE
Group top-level text and inline elements into paragraphs

### DIFF
--- a/src/converters/fromHtml.test.js
+++ b/src/converters/fromHtml.test.js
@@ -251,3 +251,67 @@ describe('convertFromHTML parsing html with nested divs', () => {
     });
   });
 });
+
+describe('convertFromHTML parsing unwrapped text', () => {
+  const html = 'text with an <b>inline element</b> and more text';
+
+  describe('with slate converter', () => {
+    const result = convertFromHTML(html, 'slate');
+
+    test('will return a block with the text in a paragraph', () => {
+      expect(result).toHaveLength(1);
+      expect(result[0].value).toEqual([
+        {
+          type: 'p',
+          children: [
+            { text: 'text with an ' },
+            { type: 'strong', children: [{ text: 'inline element' }] },
+            { text: ' and more text' },
+          ],
+        },
+      ]);
+    });
+  });
+});
+
+describe('convertFromHTML parsing unwrapped text with blocks', () => {
+  const html = 'text with a <div>block element</div> and more text';
+
+  describe('with slate converter', () => {
+    const result = convertFromHTML(html, 'slate');
+
+    test('will return 3 blocks with the text in paragraphs', () => {
+      expect(result).toHaveLength(3);
+      expect(result[0].value).toEqual([
+        { type: 'p', children: [{ text: 'text with a ' }] },
+      ]);
+      expect(result[1].value).toEqual([
+        { type: 'p', children: [{ text: 'block element' }] },
+      ]);
+      expect(result[2].value).toEqual([
+        { type: 'p', children: [{ text: ' and more text' }] },
+      ]);
+    });
+  });
+});
+
+describe('convertFromHTML parsing div with br tags', () => {
+  const html = '<div><b>Foo</b> <br /><br />Bar</div>';
+
+  describe('with slate converter', () => {
+    const result = convertFromHTML(html, 'slate');
+
+    test('will return a block with the text in a paragraph', () => {
+      expect(result).toHaveLength(1);
+      expect(result[0].value).toEqual([
+        {
+          type: 'p',
+          children: [
+            { type: 'strong', children: [{ text: 'Foo' }] },
+            { text: '\n\nBar' },
+          ],
+        },
+      ]);
+    });
+  });
+});

--- a/src/converters/fromHtml.test.js
+++ b/src/converters/fromHtml.test.js
@@ -315,3 +315,17 @@ describe('convertFromHTML parsing div with br tags', () => {
     });
   });
 });
+
+describe('convertFromHTML parsing whitespace inside unknown tags', () => {
+  const html = '<center>\n<strong>text</strong>\n</center>';
+
+  describe('returns valid result preserving the whitespace', () => {
+    const result = convertFromHTML(html, 'slate');
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toEqual([
+      { text: ' ' },
+      { type: 'strong', children: [{ text: 'text' }] },
+      { text: ' ' },
+    ]);
+  });
+});

--- a/src/converters/slate.js
+++ b/src/converters/slate.js
@@ -263,9 +263,7 @@ const slateTableBlock = (elem) => {
         const cells = [];
         for (const cell of tchild.children) {
           const cellType = cell.tagName === 'TD' ? 'data' : 'header';
-          const cellValue = Array.from(cell.childNodes)
-            .map(deserialize)
-            .filter((x) => x);
+          const cellValue = deserializeChildren(cell).filter((x) => x);
           cells.push(createCell(cellType, cellValue));
         }
         rows.push({ key: getId(), cells });

--- a/src/converters/slate.test.js
+++ b/src/converters/slate.test.js
@@ -108,6 +108,26 @@ describe('slateTextBlock processing a paragraph', () => {
       );
     });
   });
+
+  describe('with whitespace between inline elements', () => {
+    const elem = elementFromString(
+      '<p><em>em</em> <strong>strong</strong></p>',
+    );
+
+    test('will preserve the whitespace', () => {
+      const result = slateTextBlock(elem);
+      expect(result.value).toEqual([
+        {
+          type: 'p',
+          children: [
+            { type: 'em', children: [{ text: 'em' }] },
+            { text: ' ' },
+            { type: 'strong', children: [{ text: 'strong' }] },
+          ],
+        },
+      ]);
+    });
+  });
 });
 
 describe('slateTextBlock processing a simple pre block', () => {
@@ -139,10 +159,10 @@ describe('slateTextBlock processing a pre block with nested code element', () =>
 describe('slateTextBlock processing a br', () => {
   const elem = elementFromString('<br>');
 
-  test('will have a nested structure in the value', () => {
+  test('will have text with a newline', () => {
     const result = slateTextBlock(elem);
     expect(result.plaintext).toBe('');
-    expect(result.value[0]).toMatch(/\n/);
+    expect(result.value).toEqual([{ text: '\n' }]);
   });
 });
 
@@ -550,14 +570,14 @@ describe('slateTableBlock processing a table with whitespace', () => {
     '<table><tr><td>A value<br>&nbsp;</td></tr></table>',
   );
 
-  test('will remove the whitespace', () => {
+  test('will preserve the whitespace', () => {
     const result = slateTableBlock(elem);
     const rows = result.table.rows;
     expect(rows).toHaveLength(1);
     const cells = rows[0].cells;
     expect(cells).toHaveLength(1);
     const cell = cells[0];
-    expect(cell.value).toEqual([{ text: 'A value' }, { text: '\n' }]);
+    expect(cell.value).toEqual([{ text: 'A value\n\xa0' }]);
   });
 });
 

--- a/src/converters/slate.test.js
+++ b/src/converters/slate.test.js
@@ -492,6 +492,27 @@ describe('slateTextBlock processing a link', () => {
   });
 });
 
+describe('slateTextBlock processing a hr tag', () => {
+  const elem = elementFromString('<hr>');
+
+  test('will have @type as slate', () => {
+    const result = slateTextBlock(elem);
+    expect(result['@type']).toBe('slate');
+  });
+
+  test('will have an empty string for plaintext', () => {
+    const result = slateTextBlock(elem);
+    expect(result.plaintext).toBe('');
+  });
+
+  test('will have a nested structure in the value', () => {
+    const result = slateTextBlock(elem);
+    const valueElement = result.value[0];
+    expect(valueElement['type']).toBe('p');
+    expect(valueElement['children'][0]['text']).toBe('');
+  });
+});
+
 describe('slateTableBlock processing a simple table', () => {
   const elem = elementFromString('<table><tr><td>A value</td></tr></table>');
 
@@ -598,43 +619,36 @@ describe('slateTableBlock processing a table with a link', () => {
     expect(value['data']['url']).toBe('https://plone.org');
     expect(value['children'][0]['text']).toBe('site');
   });
+});
 
-  describe('slateTextBlock processing a hr tag', () => {
-    const elem = elementFromString('<hr>');
+describe('slateTableBlock processing a table with text + sup', () => {
+  const elem = elementFromString(
+    '<table><tr><td>10<sup>2</sup></td></tr></table>',
+  );
 
-    test('will have @type as slate', () => {
-      const result = slateTextBlock(elem);
-      expect(result['@type']).toBe('slate');
-    });
-
-    test('will have an empty string for plaintext', () => {
-      const result = slateTextBlock(elem);
-      expect(result.plaintext).toBe('');
-    });
-
-    test('will have a nested structure in the value', () => {
-      const result = slateTextBlock(elem);
-      const valueElement = result.value[0];
-      expect(valueElement['type']).toBe('p');
-      expect(valueElement['children'][0]['text']).toBe('');
-    });
+  test('will keep sup inline', () => {
+    const result = slateTableBlock(elem);
+    const cell = result.table.rows[0].cells[0];
+    expect(cell.value).toEqual([
+      { text: '10' },
+      {
+        type: 'sup',
+        children: [{ text: '2' }],
+      },
+    ]);
   });
+});
 
-  describe('slateTableBlock processing a table with text + sup', () => {
-    const elem = elementFromString(
-      '<table><tr><td>10<sup>2</sup></td></tr></table>',
-    );
+describe('slateTableBlock processing a table with a div', () => {
+  const elem = elementFromString(
+    '<table><tr><td><div><strong>text</strong></div></td></tr></table>',
+  );
 
-    test('will keep sup inline', () => {
-      const result = slateTableBlock(elem);
-      const cell = result.table.rows[0].cells[0];
-      expect(cell.value).toEqual([
-        { text: '10' },
-        {
-          type: 'sup',
-          children: [{ text: '2' }],
-        },
-      ]);
-    });
+  test('will remove the div', () => {
+    const result = slateTableBlock(elem);
+    const cell = result.table.rows[0].cells[0];
+    expect(cell.value).toEqual([
+      { type: 'strong', children: [{ text: 'text' }] },
+    ]);
   });
 });

--- a/src/helpers/dom.js
+++ b/src/helpers/dom.js
@@ -4,9 +4,54 @@ const DOMParser = new JSDOM().window.DOMParser;
 const parser = new DOMParser();
 
 const elementFromString = (value) => {
-  const elem = parser.parseFromString(value, 'text/html').body
-    .firstElementChild;
+  const elem = parser.parseFromString(value, 'text/html').body.firstChild;
   return elem;
 };
 
-export { elementFromString };
+const isWhitespace = (c) => {
+  return (
+    typeof c === 'string' &&
+    c.replace(/\s/g, '').replace(/\t/g, '').replace(/\n/g, '').length === 0
+  );
+};
+
+const groupInlineNodes = (inNodes, { isInline, createParent, appendChild }) => {
+  // Process a list of DOM nodes.
+  // Return a new list of nodes where each sequence of non-block nodes
+  // (text and inline elements) have been wrapped in a new block node.
+  const nodes = [];
+  let inlineNodes = null;
+
+  inNodes.forEach((node) => {
+    if (!isInline(node)) {
+      inlineNodes = null;
+      nodes.push(node);
+    } else {
+      if (!inlineNodes) {
+        inlineNodes = createParent(node);
+        nodes.push(inlineNodes);
+      } else {
+        appendChild(inlineNodes, node);
+      }
+    }
+  });
+  return nodes;
+};
+
+const inlineElements = [
+  'b',
+  'br',
+  'code',
+  'em',
+  'i',
+  'link',
+  's',
+  'strong',
+  'sub',
+  'sup',
+  'u',
+];
+
+const isGlobalInline = (tagName) => inlineElements.includes(tagName);
+
+export { elementFromString, isWhitespace, isGlobalInline, groupInlineNodes };

--- a/src/helpers/dom.js
+++ b/src/helpers/dom.js
@@ -9,10 +9,7 @@ const elementFromString = (value) => {
 };
 
 const isWhitespace = (c) => {
-  return (
-    typeof c === 'string' &&
-    c.replace(/\s/g, '').replace(/\t/g, '').replace(/\n/g, '').length === 0
-  );
+  return typeof c === 'string' && c.replace(/[\t\n\r ]/g, '').length === 0;
 };
 
 const groupInlineNodes = (inNodes, { isInline, createParent, appendChild }) => {


### PR DESCRIPTION
This fixes #16 and #17. Previously unenclosed text nodes were dropped entirely.

Also now includes fixes for two other issues that were found while testing the migration of plone.org:
1. Fixed invalid output of nested lists for a table cell containing a div
2. Fixed invalid output of null for whitespace between tags