### PR TITLE
feat: Import relevant slateTable settings for HTML ui-tables

### DIFF
--- a/src/converters/slate.js
+++ b/src/converters/slate.js
@@ -304,6 +304,23 @@ const slateTableBlock = (elem) => {
     }
   }
   block.table = createTable(rows);
+
+  const classes = elem.className.split(' ');
+  if (
+    classes.length > 0 &&
+    classes.includes('ui') &&
+    classes.includes('table')
+  ) {
+    // if table element has the classes "ui" and "table" we assume
+    // further settings-relevant classes were set (or not set) explicitly,
+    // so we set settings based on those classes, instead of using the defaults
+    const toCheck = ['basic', 'celled', 'compact', 'fixed', 'striped'];
+    for (const c of toCheck) {
+      if (classes.includes(c)) block.table[c] = true;
+      else block.table[c] = false;
+    }
+  }
+
   return block;
 };
 

--- a/src/converters/slate.js
+++ b/src/converters/slate.js
@@ -316,8 +316,7 @@ const slateTableBlock = (elem) => {
     // so we set settings based on those classes, instead of using the defaults
     const toCheck = ['basic', 'celled', 'compact', 'fixed', 'striped'];
     for (const c of toCheck) {
-      if (classes.includes(c)) block.table[c] = true;
-      else block.table[c] = false;
+      block.table[c] = classes.includes(c);
     }
   }
 

--- a/src/converters/slate.test.js
+++ b/src/converters/slate.test.js
@@ -885,3 +885,45 @@ describe('slateTableBlock parsing table with line break', () => {
     expect(value['children'][0]['text']).toEqual('\n');
   });
 });
+
+describe('slateTableBlock parsing ui table with settings classes', () => {
+  const elem = elementFromString(
+    '<table class="ui celled fixed striped very basic compact table"><tbody class=""><tr class=""><th class=""><p>Vorname</p></th><th class=""><p>Nachname</p></th></tr><tr class=""><td class=""><p>Jerry</p></td><td class=""><p>Smith</p></td></tr><tr class=""><td class=""><p>Morty</p></td><td class=""><p>Smith</p></td></tr><tr class=""><td class=""><p>Rick</p></td><td class=""><p>Sanchez</p></td></tr></tbody></table>',
+  );
+  test('returns valid result with the correct settings', () => {
+    const block = slateTableBlock(elem);
+    expect(block['@type']).toEqual('slateTable');
+    const table = block['table'];
+    const rows = table['rows'];
+    expect(rows).toHaveLength(4);
+    // we do not expect the default settings
+    expect(table.basic).toBeTruthy();
+    expect(table.celled).toBeTruthy();
+    expect(table.compact).toBeTruthy();
+    expect(table.fixed).toBeTruthy();
+    expect(table.striped).toBeTruthy();
+    // should not be affected anyways
+    expect(table.inverted).toBeFalsy();
+  });
+});
+
+describe('slateTableBlock parsing non-ui table with settings classes', () => {
+  const elem = elementFromString(
+    '<table class="celled fixed striped very basic compact"><tbody class=""><tr class=""><th class=""><p>Vorname</p></th><th class=""><p>Nachname</p></th></tr><tr class=""><td class=""><p>Jerry</p></td><td class=""><p>Smith</p></td></tr><tr class=""><td class=""><p>Morty</p></td><td class=""><p>Smith</p></td></tr><tr class=""><td class=""><p>Rick</p></td><td class=""><p>Sanchez</p></td></tr></tbody></table>',
+  );
+  test('returns valid result with the correct settings', () => {
+    const block = slateTableBlock(elem);
+    expect(block['@type']).toEqual('slateTable');
+    const table = block['table'];
+    const rows = table['rows'];
+    expect(rows).toHaveLength(4);
+    // we expect the default settings
+    expect(table.basic).toBeFalsy();
+    expect(table.celled).toBeTruthy();
+    expect(table.compact).toBeFalsy();
+    expect(table.fixed).toBeTruthy();
+    expect(table.striped).toBeFalsy();
+    // should not be affected anyways
+    expect(table.inverted).toBeFalsy();
+  });
+});


### PR DESCRIPTION
When migrating a Plone page using DraftJS to Slate (via DraftJS -> HTML -> Slate) we do not want to lose table block settings.

So I propose respecting the table settings by evaluating its classes when converting a HTML to a Slate table.
To avoid applying this behavior to "usual" HTML tables (and messing up the default settings for those cases) I propose only to apply this behavior to tables having the classes `ui table` .