### PR TITLE
fix: Fix an edge case with empty table cells

### DIFF
--- a/src/converters/fromHtml.test.js
+++ b/src/converters/fromHtml.test.js
@@ -509,6 +509,14 @@ describe('convertFromHTML parsing image', () => {
       title: '',
       url: 'image.jpeg',
     });
+    expect(result[1].table.rows[0].cells[0].type).toEqual('header');
+    expect(result[1].table.rows[0].cells[0].value).toEqual([
+      { type: 'div', children: [{ text: '' }] },
+    ]);
+    expect(result[1].table.rows[1].cells[0].type).toEqual('data');
+    expect(result[1].table.rows[1].cells[0].value).toEqual([
+      { type: 'div', children: [{ text: '' }] },
+    ]);
   });
 });
 

--- a/src/converters/slate.js
+++ b/src/converters/slate.js
@@ -306,7 +306,8 @@ const slateTableBlock = (elem) => {
         const cells = [];
         for (const cell of tchild.children) {
           const cellType = cell.tagName === 'TD' ? 'data' : 'header';
-          const cellValue = deserializeChildren(cell);
+          let cellValue = deserializeChildren(cell);
+          if (!cellValue.length) cellValue = [''];
           cells.push(createCell(cellType, cellValue));
         }
         rows.push({ key: getId(), cells });


### PR DESCRIPTION
If a table cell contained only an image, then the converted block value included a div with no children, which breaks the slate editor.