### PR TITLE
fix: Fixed a bug where some nodes could be skipped after converting an element to a block

### DIFF
--- a/src/converters/fromHtml.js
+++ b/src/converters/fromHtml.js
@@ -97,7 +97,7 @@ const extractElementsWithConverters = (el, defaultTextBlock, href) => {
     href = el.getAttribute('href');
   }
   // First, traverse all childNodes
-  for (const child of el.childNodes) {
+  for (const child of Array.from(el.childNodes)) {
     const tmpResult = extractElementsWithConverters(
       child,
       defaultTextBlock,
@@ -146,7 +146,7 @@ const convertFromHTML = (input, defaultTextBlock) => {
 
   // convert to blocks
   for (const el of elements) {
-    const children = el.childNodes;
+    const children = Array.from(el.childNodes);
     const href = el.getAttribute('href');
     for (const child of children) {
       // With children nodes, we keep the wrapper only

--- a/src/converters/fromHtml.test.js
+++ b/src/converters/fromHtml.test.js
@@ -350,6 +350,30 @@ describe('convertFromHTML parsing image', () => {
     ]);
   });
 
+  test('inside a block element with another image', () => {
+    const html = '<div><img src="image1.jpg"><img src="image2.jpg"></div>';
+
+    const result = convertFromHTML(html, 'slate');
+    expect(result).toEqual([
+      {
+        '@type': 'image',
+        align: 'center',
+        alt: '',
+        size: 'l',
+        title: '',
+        url: 'image1.jpg',
+      },
+      {
+        '@type': 'image',
+        align: 'center',
+        alt: '',
+        size: 'l',
+        title: '',
+        url: 'image2.jpg',
+      },
+    ]);
+  });
+
   test('inside a p element', () => {
     const html = '<p><img src="image.jpeg"></p>';
 


### PR DESCRIPTION
This is the old "don't mutate a list while iterating over it" bug. Using Array.from creates a new list of the children which will not be mutated when the DOM is later modified.